### PR TITLE
lame update

### DIFF
--- a/cross/lame/Makefile
+++ b/cross/lame/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME = lame
 PKG_VERS_MAJOR = 3.99
-PKG_VERS = $(PKG_VERS_MAJOR).4
+PKG_VERS = $(PKG_VERS_MAJOR).5
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://downloads.sourceforge.net/project/lame/$(PKG_NAME)/$(PKG_VERS_MAJOR)


### PR DESCRIPTION
Update lame to version 3.99.5

because the version 3.99.4 doesn't exist anymore.